### PR TITLE
feat: add lineWidth prop

### DIFF
--- a/src/Liveline.tsx
+++ b/src/Liveline.tsx
@@ -47,6 +47,7 @@ export function Liveline({
   onHover,
   cursor = 'crosshair',
   pulse = true,
+  lineWidth,
   className,
   style,
 }: LivelineProps) {
@@ -57,7 +58,11 @@ export function Liveline({
   const windowBtnRefs = useRef<Map<number, HTMLButtonElement>>(new Map())
   const [indicatorStyle, setIndicatorStyle] = useState<{ left: number; width: number } | null>(null)
 
-  const palette = useMemo(() => resolveTheme(color, theme), [color, theme])
+  const palette = useMemo(() => {
+    const p = resolveTheme(color, theme)
+    if (lineWidth != null) p.lineWidth = lineWidth
+    return p
+  }, [color, theme, lineWidth])
   const isDark = theme === 'dark'
 
   // Resolve momentum prop: boolean enables auto-detect, string overrides

--- a/src/types.ts
+++ b/src/types.ts
@@ -96,6 +96,7 @@ export interface LivelineProps {
   onHover?: (point: HoverPoint | null) => void
   cursor?: string          // CSS cursor on hover (default: 'crosshair')
   pulse?: boolean          // Pulsing ring on live dot (default: true)
+  lineWidth?: number       // Stroke width of the main line in px (default: 2)
 
   className?: string
   style?: CSSProperties


### PR DESCRIPTION
## Summary

Adds an optional `lineWidth` prop to `<Liveline>` that overrides the default 2px stroke width of the main chart line.

- Adds `lineWidth?: number` to `LivelineProps`
- Overrides `palette.lineWidth` when provided
- No breaking changes — defaults to existing behavior (2px)

### Usage

```tsx
<Liveline lineWidth={3} />
```

### Motivation

We're using Liveline in a trading app and needed a slightly thicker line (3px) for better visibility on mobile. Currently the only way to change this is patching `node_modules`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)