### PR TITLE
Add Bar Chart

### DIFF
--- a/dev/demo.tsx
+++ b/dev/demo.tsx
@@ -124,6 +124,7 @@ function Demo() {
   const [windowSecs, setWindowSecs] = useState(30)
   const [theme, setTheme] = useState<'dark' | 'light'>('dark')
   const [grid, setGrid] = useState(true)
+  const [badge, setBadge] = useState(true)
   const [scrub, setScrub] = useState(true)
 
   const [volatility, setVolatility] = useState<Volatility>('normal')
@@ -392,6 +393,7 @@ function Demo() {
         <Btn active={theme === 'light'} onClick={() => setTheme('light')}>Light</Btn>
         <Sep />
         <Toggle on={grid} onToggle={setGrid}>Grid</Toggle>
+        <Toggle on={badge} onToggle={setBadge}>Badge</Toggle>
         <Toggle on={scrub} onToggle={setScrub}>Scrub</Toggle>
       </Section>
 
@@ -424,6 +426,7 @@ function Demo() {
           formatValue={preset === 'crypto' ? formatCrypto : undefined}
           onModeChange={(mode) => setChartType(mode)}
           grid={grid}
+          badge={badge}
           scrub={scrub}
         />
       </div>
@@ -466,6 +469,7 @@ function Demo() {
                 window={windowSecs}
                 formatValue={preset === 'crypto' ? formatCrypto : undefined}
                 grid={grid && size.w >= 200}
+                badge={badge && size.w >= 200}
                 scrub={scrub}
               />
             </div>
@@ -508,6 +512,7 @@ function Demo() {
           formatValue={preset === 'crypto' ? formatCrypto : undefined}
           onModeChange={(mode) => setChartType(mode)}
           grid={grid}
+          badge={badge}
           scrub={scrub}
           bars={bars}
           barMode={barMode}

--- a/dev/demo.tsx
+++ b/dev/demo.tsx
@@ -129,6 +129,7 @@ function Demo() {
   const [volatility, setVolatility] = useState<Volatility>('normal')
   const [tickRate, setTickRate] = useState(300)
   const [bars, setBars] = useState<BarPoint[]>([])
+  const [barMode, setBarMode] = useState<'default' | 'overlay'>('default')
   const [barLabels, setBarLabels] = useState(false)
   const barBucketSecs = 2
 
@@ -392,7 +393,6 @@ function Demo() {
         <Sep />
         <Toggle on={grid} onToggle={setGrid}>Grid</Toggle>
         <Toggle on={scrub} onToggle={setScrub}>Scrub</Toggle>
-        <Toggle on={barLabels} onToggle={setBarLabels}>Bar labels</Toggle>
       </Section>
 
       {/* Main chart */}
@@ -473,36 +473,14 @@ function Demo() {
         ))}
       </div>
 
-      {/* Bar chart — default mode */}
-      <p style={{ fontSize: 12, color: 'var(--fg-30)', marginTop: 24, marginBottom: 8 }}>Volume bars (default)</p>
-      <div style={{
-        height: 320,
-        background: 'var(--fg-02)',
-        borderRadius: 12,
-        border: '1px solid var(--fg-06)',
-        padding: 8,
-        overflow: 'hidden',
-      }}>
-        <Liveline
-          data={data}
-          value={value}
-          loading={loading}
-          paused={paused}
-          theme={theme}
-          color={preset === 'crypto' ? '#f7931a' : undefined}
-          window={windowSecs}
-          formatValue={preset === 'crypto' ? formatCrypto : undefined}
-          grid={grid}
-          scrub={scrub}
-          bars={bars}
-          barMode="default"
-          barWidth={barBucketSecs}
-          barLabels={barLabels}
-        />
+      {/* Volume bars */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 24, marginBottom: 8 }}>
+        <p style={{ fontSize: 12, color: 'var(--fg-30)', margin: 0 }}>Volume bars</p>
+        <Btn active={barMode === 'default'} onClick={() => setBarMode('default')}>Default</Btn>
+        <Btn active={barMode === 'overlay'} onClick={() => setBarMode('overlay')}>Overlay</Btn>
+        <Sep />
+        <Toggle on={barLabels} onToggle={setBarLabels}>Labels</Toggle>
       </div>
-
-      {/* Bar chart — overlay mode */}
-      <p style={{ fontSize: 12, color: 'var(--fg-30)', marginTop: 24, marginBottom: 8 }}>Volume bars (overlay)</p>
       <div style={{
         height: 320,
         background: 'var(--fg-02)',
@@ -512,18 +490,27 @@ function Demo() {
         overflow: 'hidden',
       }}>
         <Liveline
+          mode="candle"
           data={data}
           value={value}
+          candles={candles}
+          candleWidth={candleSecs}
+          liveCandle={liveCandle ?? undefined}
+          lineMode={chartType === 'line'}
+          lineData={data}
+          lineValue={value}
           loading={loading}
           paused={paused}
           theme={theme}
           color={preset === 'crypto' ? '#f7931a' : undefined}
           window={windowSecs}
+          windows={preset === 'crypto' ? CRYPTO_WINDOWS : undefined}
           formatValue={preset === 'crypto' ? formatCrypto : undefined}
+          onModeChange={(mode) => setChartType(mode)}
           grid={grid}
           scrub={scrub}
           bars={bars}
-          barMode="overlay"
+          barMode={barMode}
           barWidth={barBucketSecs}
           barLabels={barLabels}
         />

--- a/dev/demo.tsx
+++ b/dev/demo.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react'
 import { createRoot } from 'react-dom/client'
 import { Liveline } from 'liveline'
-import type { LivelinePoint, CandlePoint } from 'liveline'
+import type { LivelinePoint, CandlePoint, BarPoint } from 'liveline'
 
 // --- Data generators ---
 
@@ -38,6 +38,42 @@ function aggregateCandles(ticks: LivelinePoint[], width: number): { candles: Can
     }
   }
   return { candles, live: { time: slot, open: o, high: h, low: l, close: c } }
+}
+
+/** Generate initial volume bars from seed data */
+function generateBars(data: LivelinePoint[], bucketSecs: number): BarPoint[] {
+  if (data.length === 0) return []
+  const bars: BarPoint[] = []
+  const startTime = Math.floor(data[0].time / bucketSecs) * bucketSecs
+  let bucketStart = startTime
+  let bucketVolume = 0
+  let prevValue = data[0].value
+  for (const pt of data) {
+    while (pt.time >= bucketStart + bucketSecs) {
+      if (bucketVolume > 0) bars.push({ time: bucketStart, value: bucketVolume })
+      bucketStart += bucketSecs
+      bucketVolume = 0
+    }
+    const change = Math.abs(pt.value - prevValue)
+    bucketVolume += 10 + change * 20 + Math.random() * 5
+    prevValue = pt.value
+  }
+  if (bucketVolume > 0) bars.push({ time: bucketStart, value: bucketVolume })
+  return bars
+}
+
+/** Incrementally update bars with a new data point — only touches the last bucket */
+function addTickToBars(bars: BarPoint[], pt: LivelinePoint, prevValue: number, bucketSecs: number): BarPoint[] {
+  const bucketStart = Math.floor(pt.time / bucketSecs) * bucketSecs
+  const change = Math.abs(pt.value - prevValue)
+  const volume = 10 + change * 20 + Math.random() * 5
+  if (bars.length === 0 || bars[bars.length - 1].time < bucketStart) {
+    return [...bars, { time: bucketStart, value: volume }]
+  }
+  const updated = bars.slice()
+  const last = updated[updated.length - 1]
+  updated[updated.length - 1] = { time: last.time, value: last.value + volume }
+  return updated
 }
 
 // --- Constants ---
@@ -92,6 +128,9 @@ function Demo() {
 
   const [volatility, setVolatility] = useState<Volatility>('normal')
   const [tickRate, setTickRate] = useState(300)
+  const [bars, setBars] = useState<BarPoint[]>([])
+  const [barLabels, setBarLabels] = useState(false)
+  const barBucketSecs = 2
 
   const [chartType, setChartType] = useState<'line' | 'candle'>('candle')
   const [candleSecs, setCandleSecs] = useState(2)
@@ -162,10 +201,12 @@ function Demo() {
     setCandles(agg.candles)
     setLiveCandle(agg.live)
     liveCandleRef.current = agg.live ? { ...agg.live } : null
+    setBars(generateBars(seed, barBucketSecs))
 
     intervalRef.current = window.setInterval(() => {
       const now = Date.now() / 1000
-      const pt = generatePoint(lastValueRef.current, now, volatilityRef.current, startValueRef.current)
+      const prevVal = lastValueRef.current
+      const pt = generatePoint(prevVal, now, volatilityRef.current, startValueRef.current)
       lastValueRef.current = pt.value
       setValue(pt.value)
       setData(prev => {
@@ -175,6 +216,7 @@ function Demo() {
         return trimmed
       })
       tickAndAggregate(pt)
+      setBars(prev => addTickToBars(prev, pt, prevVal, barBucketSecs))
     }, tickRate)
   }, [tickRate])
 
@@ -182,7 +224,7 @@ function Demo() {
     if (scenario === 'loading') {
       setLoading(true)
       setData([]); dataRef.current = []
-      setCandles([]); setLiveCandle(null); liveCandleRef.current = null
+      setCandles([]); setLiveCandle(null); liveCandleRef.current = null; setBars([])
       clearInterval(intervalRef.current)
       const timer = setTimeout(() => setScenario('live'), 3000)
       return () => clearTimeout(timer)
@@ -191,7 +233,7 @@ function Demo() {
     if (scenario === 'loading-hold') {
       setLoading(true)
       setData([]); dataRef.current = []
-      setCandles([]); setLiveCandle(null); liveCandleRef.current = null
+      setCandles([]); setLiveCandle(null); liveCandleRef.current = null; setBars([])
       clearInterval(intervalRef.current)
       return
     }
@@ -199,7 +241,7 @@ function Demo() {
     if (scenario === 'empty') {
       setLoading(false)
       setData([]); dataRef.current = []
-      setCandles([]); setLiveCandle(null); liveCandleRef.current = null
+      setCandles([]); setLiveCandle(null); liveCandleRef.current = null; setBars([])
       clearInterval(intervalRef.current)
       return
     }
@@ -213,7 +255,8 @@ function Demo() {
     clearInterval(intervalRef.current)
     intervalRef.current = window.setInterval(() => {
       const now = Date.now() / 1000
-      const pt = generatePoint(lastValueRef.current, now, volatilityRef.current, startValueRef.current)
+      const prevVal = lastValueRef.current
+      const pt = generatePoint(prevVal, now, volatilityRef.current, startValueRef.current)
       lastValueRef.current = pt.value
       setValue(pt.value)
       setData(prev => {
@@ -223,6 +266,7 @@ function Demo() {
         return trimmed
       })
       tickAndAggregate(pt)
+      setBars(prev => addTickToBars(prev, pt, prevVal, barBucketSecs))
     }, tickRate)
     return () => clearInterval(intervalRef.current)
   }, [tickRate, scenario])
@@ -260,7 +304,7 @@ function Demo() {
     }
     // Force re-seed by cycling to loading
     setData([]); dataRef.current = []
-    setCandles([]); setLiveCandle(null); liveCandleRef.current = null
+    setCandles([]); setLiveCandle(null); liveCandleRef.current = null; setBars([])
     lastValueRef.current = preset === 'crypto' ? 65000 : 100
     clearInterval(intervalRef.current)
     setLoading(true)
@@ -348,6 +392,7 @@ function Demo() {
         <Sep />
         <Toggle on={grid} onToggle={setGrid}>Grid</Toggle>
         <Toggle on={scrub} onToggle={setScrub}>Scrub</Toggle>
+        <Toggle on={barLabels} onToggle={setBarLabels}>Bar labels</Toggle>
       </Section>
 
       {/* Main chart */}
@@ -426,6 +471,62 @@ function Demo() {
             </div>
           </div>
         ))}
+      </div>
+
+      {/* Bar chart — default mode */}
+      <p style={{ fontSize: 12, color: 'var(--fg-30)', marginTop: 24, marginBottom: 8 }}>Volume bars (default)</p>
+      <div style={{
+        height: 320,
+        background: 'var(--fg-02)',
+        borderRadius: 12,
+        border: '1px solid var(--fg-06)',
+        padding: 8,
+        overflow: 'hidden',
+      }}>
+        <Liveline
+          data={data}
+          value={value}
+          loading={loading}
+          paused={paused}
+          theme={theme}
+          color={preset === 'crypto' ? '#f7931a' : undefined}
+          window={windowSecs}
+          formatValue={preset === 'crypto' ? formatCrypto : undefined}
+          grid={grid}
+          scrub={scrub}
+          bars={bars}
+          barMode="default"
+          barWidth={barBucketSecs}
+          barLabels={barLabels}
+        />
+      </div>
+
+      {/* Bar chart — overlay mode */}
+      <p style={{ fontSize: 12, color: 'var(--fg-30)', marginTop: 24, marginBottom: 8 }}>Volume bars (overlay)</p>
+      <div style={{
+        height: 320,
+        background: 'var(--fg-02)',
+        borderRadius: 12,
+        border: '1px solid var(--fg-06)',
+        padding: 8,
+        overflow: 'hidden',
+      }}>
+        <Liveline
+          data={data}
+          value={value}
+          loading={loading}
+          paused={paused}
+          theme={theme}
+          color={preset === 'crypto' ? '#f7931a' : undefined}
+          window={windowSecs}
+          formatValue={preset === 'crypto' ? formatCrypto : undefined}
+          grid={grid}
+          scrub={scrub}
+          bars={bars}
+          barMode="overlay"
+          barWidth={barBucketSecs}
+          barLabels={barLabels}
+        />
       </div>
 
       {/* Status bar */}

--- a/dev/main.tsx
+++ b/dev/main.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react'
 import { createRoot } from 'react-dom/client'
 import { Liveline } from 'liveline'
-import type { LivelinePoint } from 'liveline'
+import type { LivelinePoint, BarPoint } from 'liveline'
 
 // --- Data generators ---
 
@@ -17,6 +17,42 @@ function generatePoint(prev: number, time: number, volatility: Volatility): Live
     : 0
   const delta = (Math.random() - bias[volatility]) * scale + spike
   return { time, value: prev + delta }
+}
+
+/** Generate initial volume bars from seed data */
+function generateBars(data: LivelinePoint[], bucketSecs: number): BarPoint[] {
+  if (data.length === 0) return []
+  const bars: BarPoint[] = []
+  const startTime = Math.floor(data[0].time / bucketSecs) * bucketSecs
+  let bucketStart = startTime
+  let bucketVolume = 0
+  let prevValue = data[0].value
+  for (const pt of data) {
+    while (pt.time >= bucketStart + bucketSecs) {
+      if (bucketVolume > 0) bars.push({ time: bucketStart, value: bucketVolume })
+      bucketStart += bucketSecs
+      bucketVolume = 0
+    }
+    const change = Math.abs(pt.value - prevValue)
+    bucketVolume += 10 + change * 20 + Math.random() * 5
+    prevValue = pt.value
+  }
+  if (bucketVolume > 0) bars.push({ time: bucketStart, value: bucketVolume })
+  return bars
+}
+
+/** Incrementally update bars with a new data point — only touches the last bucket */
+function addTickToBars(bars: BarPoint[], pt: LivelinePoint, prevValue: number, bucketSecs: number): BarPoint[] {
+  const bucketStart = Math.floor(pt.time / bucketSecs) * bucketSecs
+  const change = Math.abs(pt.value - prevValue)
+  const volume = 10 + change * 20 + Math.random() * 5
+  if (bars.length === 0 || bars[bars.length - 1].time < bucketStart) {
+    return [...bars, { time: bucketStart, value: volume }]
+  }
+  const updated = bars.slice()
+  const last = updated[updated.length - 1]
+  updated[updated.length - 1] = { time: last.time, value: last.value + volume }
+  return updated
 }
 
 // --- Constants ---
@@ -60,6 +96,10 @@ function Demo() {
   const [scrub, setScrub] = useState(true)
   const [exaggerate, setExaggerate] = useState(false)
   const [theme, setTheme] = useState<'dark' | 'light'>('dark')
+  const [bars, setBars] = useState<BarPoint[]>([])
+  const [barMode, setBarMode] = useState<'default' | 'overlay'>('default')
+  const [barLabels, setBarLabels] = useState(false)
+  const barBucketSecs = 2
 
   // Data controls
   const [volatility, setVolatility] = useState<Volatility>('normal')
@@ -68,6 +108,7 @@ function Demo() {
   const intervalRef = useRef<number>(0)
   const volatilityRef = useRef(volatility)
   volatilityRef.current = volatility
+  const lastValueRef = useRef(100)
 
   const startLive = useCallback(() => {
     clearInterval(intervalRef.current)
@@ -83,13 +124,18 @@ function Demo() {
     }
     setData(seed)
     setValue(v)
+    lastValueRef.current = v
+    setBars(generateBars(seed, barBucketSecs))
 
     intervalRef.current = window.setInterval(() => {
       setData(prev => {
         const now = Date.now() / 1000
         const lastVal = prev.length > 0 ? prev[prev.length - 1].value : 100
+        const prevVal = lastValueRef.current
         const pt = generatePoint(lastVal, now, volatilityRef.current)
+        lastValueRef.current = pt.value
         setValue(pt.value)
+        setBars(b => addTickToBars(b, pt, prevVal, barBucketSecs))
         const next = [...prev, pt]
         return next.length > 500 ? next.slice(-500) : next
       })
@@ -99,7 +145,7 @@ function Demo() {
   useEffect(() => {
     if (scenario === 'loading') {
       setLoading(true)
-      setData([])
+      setData([]); setBars([])
       clearInterval(intervalRef.current)
       const timer = setTimeout(() => setScenario('live'), 3000)
       return () => clearTimeout(timer)
@@ -107,14 +153,14 @@ function Demo() {
 
     if (scenario === 'loading-hold') {
       setLoading(true)
-      setData([])
+      setData([]); setBars([])
       clearInterval(intervalRef.current)
       return
     }
 
     if (scenario === 'empty') {
       setLoading(false)
-      setData([])
+      setData([]); setBars([])
       clearInterval(intervalRef.current)
       return
     }
@@ -132,8 +178,11 @@ function Demo() {
       setData(prev => {
         const now = Date.now() / 1000
         const lastVal = prev.length > 0 ? prev[prev.length - 1].value : 100
+        const prevVal = lastValueRef.current
         const pt = generatePoint(lastVal, now, volatilityRef.current)
+        lastValueRef.current = pt.value
         setValue(pt.value)
+        setBars(b => addTickToBars(b, pt, prevVal, barBucketSecs))
         const next = [...prev, pt]
         return next.length > 500 ? next.slice(-500) : next
       })
@@ -312,6 +361,45 @@ function Demo() {
             </div>
           </div>
         ))}
+      </div>
+
+      {/* Volume bars */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 24, marginBottom: 8 }}>
+        <p style={{ fontSize: 12, color: 'var(--fg-30)', margin: 0 }}>Volume bars</p>
+        <Btn active={barMode === 'default'} onClick={() => setBarMode('default')}>Default</Btn>
+        <Btn active={barMode === 'overlay'} onClick={() => setBarMode('overlay')}>Overlay</Btn>
+        <Sep />
+        <Toggle on={barLabels} onToggle={setBarLabels}>Labels</Toggle>
+      </div>
+      <div style={{
+        height: 320,
+        background: 'var(--fg-02)',
+        borderRadius: 12,
+        border: '1px solid var(--fg-06)',
+        padding: 8,
+        overflow: 'hidden',
+      }}>
+        <Liveline
+          data={data}
+          value={value}
+          theme={theme}
+          window={windowSecs}
+          loading={loading}
+          paused={paused}
+          grid={grid}
+          scrub={scrub}
+          fill={fill}
+          badge={badge}
+          badgeVariant={badgeVariant}
+          momentum={momentum}
+          pulse={pulse}
+          windows={TIME_WINDOWS}
+          onWindowChange={setWindowSecs}
+          bars={bars}
+          barMode={barMode}
+          barWidth={barBucketSecs}
+          barLabels={barLabels}
+        />
       </div>
 
       {/* Status bar */}

--- a/src/Liveline.tsx
+++ b/src/Liveline.tsx
@@ -81,9 +81,10 @@ export function Liveline({
   const momentumOverride: Momentum | undefined =
     typeof momentum === 'string' ? momentum : undefined
 
+  const defaultRight = badge ? 80 : grid ? 54 : 12
   const pad = {
     top: paddingOverride?.top ?? 12,
-    right: paddingOverride?.right ?? 80,
+    right: paddingOverride?.right ?? defaultRight,
     bottom: paddingOverride?.bottom ?? 28,
     left: paddingOverride?.left ?? 12,
   }

--- a/src/Liveline.tsx
+++ b/src/Liveline.tsx
@@ -55,6 +55,11 @@ export function Liveline({
   lineData,
   lineValue,
   onModeChange,
+  bars,
+  barMode,
+  barWidth,
+  barColor,
+  barLabels,
   className,
   style,
 }: LivelineProps) {
@@ -167,6 +172,11 @@ export function Liveline({
     lineMode,
     lineData,
     lineValue,
+    bars,
+    barMode,
+    barColor,
+    barWidthSecs: barWidth,
+    barLabels,
   })
 
   const cursorStyle = scrub ? cursor : 'default'

--- a/src/draw/bars.ts
+++ b/src/draw/bars.ts
@@ -1,0 +1,120 @@
+import type { ChartLayout, BarPoint } from '../types'
+
+export interface BarLayout {
+  /** Y pixel where bars are anchored (bottom of the bar region) */
+  bottom: number
+  /** Maximum bar height in pixels */
+  maxHeight: number
+  /** Maximum bar value — used to scale bar heights */
+  maxValue: number
+}
+
+export interface BarDrawOptions {
+  bars: BarPoint[]
+  barWidthSecs: number
+  fillColor: string
+  labelColor: string
+  scrubX: number | null
+  scrubAmount: number
+  revealProgress: number
+  showLabels: boolean
+}
+
+/**
+ * Draw vertical bars aligned to time buckets.
+ * Bars grow upward from `barLayout.bottom`.
+ * Pure drawing function — no state mutations.
+ */
+export function drawBars(
+  ctx: CanvasRenderingContext2D,
+  layout: ChartLayout,
+  barLayout: BarLayout,
+  opts: BarDrawOptions,
+): void {
+  const { bars, barWidthSecs, fillColor, scrubX, scrubAmount, revealProgress } = opts
+  if (bars.length === 0 || barLayout.maxValue <= 0) return
+
+  const { pad, chartW } = layout
+  const pxPerSec = chartW / (layout.rightEdge - layout.leftEdge)
+  const barPxWidth = Math.max(1, barWidthSecs * pxPerSec - 2) // 2px gap between bars
+  const halfBar = barPxWidth / 2
+  const cornerR = barPxWidth > 6 ? 1.5 : 0
+  const baseAlpha = ctx.globalAlpha
+
+  ctx.fillStyle = fillColor
+
+  for (let i = 0; i < bars.length; i++) {
+    const b = bars[i]
+    if (b.value <= 0) continue
+
+    const centerX = layout.toX(b.time + barWidthSecs / 2)
+    const x = centerX - halfBar
+
+    // Skip bars fully outside visible area
+    if (x + barPxWidth < pad.left || x > pad.left + chartW) continue
+
+    const rawHeight = (b.value / barLayout.maxValue) * barLayout.maxHeight
+    // During reveal, bars grow from zero height
+    const barH = rawHeight * revealProgress
+    if (barH < 0.5) continue
+
+    const barY = barLayout.bottom - barH
+
+    // Scrub dimming: bars to the right of scrubX are dimmed
+    if (scrubX !== null && scrubAmount > 0.05) {
+      const barCenter = centerX
+      if (barCenter > scrubX) {
+        ctx.globalAlpha = baseAlpha * (1 - scrubAmount * 0.6)
+      } else {
+        ctx.globalAlpha = baseAlpha
+      }
+    }
+
+    if (cornerR > 0 && barH > cornerR * 2) {
+      // Rounded top corners only
+      ctx.beginPath()
+      ctx.moveTo(x, barLayout.bottom)
+      ctx.lineTo(x, barY + cornerR)
+      ctx.arcTo(x, barY, x + cornerR, barY, cornerR)
+      ctx.lineTo(x + barPxWidth - cornerR, barY)
+      ctx.arcTo(x + barPxWidth, barY, x + barPxWidth, barY + cornerR, cornerR)
+      ctx.lineTo(x + barPxWidth, barLayout.bottom)
+      ctx.closePath()
+      ctx.fill()
+    } else {
+      ctx.fillRect(x, barY, barPxWidth, barH)
+    }
+  }
+
+  // Labels (optional) — drawn inside the bar, near the top
+  if (opts.showLabels && revealProgress > 0.5) {
+    ctx.save()
+    const fontSize = layout.w > 500 ? 9 : 8
+    ctx.font = `${fontSize}px "SF Mono", Menlo, monospace`
+    ctx.textAlign = 'center'
+    ctx.textBaseline = 'bottom'
+    ctx.fillStyle = opts.labelColor
+    ctx.globalAlpha = baseAlpha * Math.min(1, (revealProgress - 0.5) * 4)
+
+    for (let i = 0; i < bars.length; i++) {
+      const b = bars[i]
+      if (b.value <= 0) continue
+      const centerX = layout.toX(b.time + barWidthSecs / 2)
+      if (centerX < pad.left || centerX > pad.left + chartW) continue
+      const barH = (b.value / barLayout.maxValue) * barLayout.maxHeight * revealProgress
+      if (barH < fontSize + 6) continue // skip labels on bars too short to fit text
+      ctx.fillText(formatBarValue(b.value), centerX, barLayout.bottom - 3)
+    }
+    ctx.restore()
+  }
+
+  ctx.globalAlpha = baseAlpha
+}
+
+function formatBarValue(v: number): string {
+  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`
+  if (v >= 1_000) return `${(v / 1_000).toFixed(1)}K`
+  if (v >= 10) return Math.round(v).toString()
+  if (v >= 1) return v.toFixed(1)
+  return v.toFixed(2)
+}

--- a/src/draw/index.ts
+++ b/src/draw/index.ts
@@ -1,4 +1,4 @@
-import type { LivelinePalette, ChartLayout, LivelinePoint, Momentum, ReferenceLine, OrderbookData, DegenOptions, CandlePoint } from '../types'
+import type { LivelinePalette, ChartLayout, LivelinePoint, Momentum, ReferenceLine, OrderbookData, DegenOptions, CandlePoint, BarPoint } from '../types'
 import { drawGrid, type GridState } from './grid'
 import { drawLine } from './line'
 import { drawDot, drawArrows } from './dot'
@@ -9,6 +9,7 @@ import { drawOrderbook, type OrderbookState } from './orderbook'
 import { drawParticles, spawnOnSwing, type ParticleState } from './particles'
 import { drawCandlesticks, drawClosePrice, drawCandleCrosshair, drawLineModeCrosshair } from './candlestick'
 import { drawEmpty } from './empty'
+import { drawBars, type BarLayout } from './bars'
 
 // Constants
 const SHAKE_DECAY_RATE = 0.002
@@ -59,6 +60,13 @@ export interface DrawOptions {
   chartReveal: number       // 0 = loading/morphing from center, 1 = fully revealed
   pauseProgress: number     // 0 = playing, 1 = fully paused
   now_ms: number            // performance.now() for breathing animation timing
+  // Bar chart
+  bars?: BarPoint[]
+  barWidthSecs?: number
+  barMode?: 'default' | 'overlay'
+  barFillColor?: string
+  barLayout?: BarLayout
+  barShowLabels?: boolean
 }
 
 /**
@@ -124,6 +132,26 @@ export function drawFrame(
     ctx.restore()
   }
 
+  // 2c. Bars — overlay mode (behind line)
+  if (opts.bars && opts.barLayout && opts.barWidthSecs && opts.barMode === 'overlay' && opts.barFillColor) {
+    const barAlpha = reveal < 1 ? revealRamp(0.1, 0.6) : 1
+    if (barAlpha > 0.01) {
+      ctx.save()
+      if (barAlpha < 1) ctx.globalAlpha = barAlpha
+      drawBars(ctx, layout, opts.barLayout, {
+        bars: opts.bars,
+        barWidthSecs: opts.barWidthSecs,
+        fillColor: opts.barFillColor,
+        labelColor: palette.gridLabel,
+        scrubX: opts.scrubAmount > 0.05 ? opts.hoverX : null,
+        scrubAmount: opts.scrubAmount,
+        revealProgress: reveal < 1 ? revealRamp(0.1, 0.8) : 1,
+        showLabels: opts.barShowLabels ?? false,
+      })
+      ctx.restore()
+    }
+  }
+
   // 3. Line + fill (with scrub dimming + reveal morphing)
   const scrubX = opts.scrubAmount > 0.05 ? opts.hoverX : null
   const pts = drawLine(ctx, layout, palette, opts.visible, opts.smoothValue, opts.now, opts.showFill, scrubX, opts.scrubAmount, reveal, opts.now_ms)
@@ -187,6 +215,29 @@ export function drawFrame(
         shake.amplitude = (3 + opts.swingMagnitude * 4) * burstIntensity
       }
       drawParticles(ctx, opts.particleState, opts.dt)
+    }
+  }
+
+  // 6b. Bars — default mode (separate bottom strip)
+  if (opts.bars && opts.barLayout && opts.barWidthSecs && opts.barMode === 'default' && opts.barFillColor) {
+    const barAlpha = reveal < 1 ? revealRamp(0.15, 0.7) : 1
+    if (barAlpha > 0.01) {
+      ctx.save()
+      ctx.beginPath()
+      ctx.rect(layout.pad.left, opts.barLayout.bottom - opts.barLayout.maxHeight, layout.chartW, opts.barLayout.maxHeight)
+      ctx.clip()
+      if (barAlpha < 1) ctx.globalAlpha = barAlpha
+      drawBars(ctx, layout, opts.barLayout, {
+        bars: opts.bars,
+        barWidthSecs: opts.barWidthSecs,
+        fillColor: opts.barFillColor,
+        labelColor: palette.gridLabel,
+        scrubX: opts.scrubAmount > 0.05 ? opts.hoverX : null,
+        scrubAmount: opts.scrubAmount,
+        revealProgress: reveal < 1 ? revealRamp(0.1, 0.8) : 1,
+        showLabels: opts.barShowLabels ?? false,
+      })
+      ctx.restore()
     }
   }
 
@@ -268,6 +319,13 @@ export interface CandleDrawOptions {
   emptyText?: string
   loadingAlpha: number
   showEmptyOverlay: boolean  // true only when collapsing to empty (not loading, not forward morph)
+  // Bar chart
+  bars?: BarPoint[]
+  barWidthSecs?: number
+  barMode?: 'default' | 'overlay'
+  barFillColor?: string
+  barLayout?: BarLayout
+  barShowLabels?: boolean
 }
 
 /**
@@ -313,6 +371,26 @@ export function drawCandleFrame(
     if (gridAlpha < 1) ctx.globalAlpha = gridAlpha
     drawGrid(ctx, layout, palette, opts.formatValue, opts.gridState, opts.dt)
     ctx.restore()
+  }
+
+  // 1b. Bars — overlay mode (behind line + candles)
+  if (opts.bars && opts.barLayout && opts.barWidthSecs && opts.barMode === 'overlay' && opts.barFillColor) {
+    const barAlpha = reveal < 1 ? revealRamp(0.1, 0.6) : 1
+    if (barAlpha > 0.01) {
+      ctx.save()
+      if (barAlpha < 1) ctx.globalAlpha = barAlpha
+      drawBars(ctx, layout, opts.barLayout, {
+        bars: opts.bars,
+        barWidthSecs: opts.barWidthSecs,
+        fillColor: opts.barFillColor,
+        labelColor: palette.gridLabel,
+        scrubX: opts.scrubAmount > 0.05 ? opts.hoverX : null,
+        scrubAmount: opts.scrubAmount,
+        revealProgress: reveal < 1 ? revealRamp(0.1, 0.8) : 1,
+        showLabels: opts.barShowLabels ?? false,
+      })
+      ctx.restore()
+    }
   }
 
   // 2. Line — morph line that transforms from loading squiggly into data.
@@ -416,6 +494,29 @@ export function drawCandleFrame(
       )
     }
     ctx.restore()
+  }
+
+  // 4b. Bars — default mode (separate bottom strip)
+  if (opts.bars && opts.barLayout && opts.barWidthSecs && opts.barMode === 'default' && opts.barFillColor) {
+    const barAlpha = reveal < 1 ? revealRamp(0.15, 0.7) : 1
+    if (barAlpha > 0.01) {
+      ctx.save()
+      ctx.beginPath()
+      ctx.rect(pad.left, opts.barLayout.bottom - opts.barLayout.maxHeight, chartW, opts.barLayout.maxHeight)
+      ctx.clip()
+      if (barAlpha < 1) ctx.globalAlpha = barAlpha
+      drawBars(ctx, layout, opts.barLayout, {
+        bars: opts.bars,
+        barWidthSecs: opts.barWidthSecs,
+        fillColor: opts.barFillColor,
+        labelColor: palette.gridLabel,
+        scrubX: opts.scrubAmount > 0.05 ? opts.hoverX : null,
+        scrubAmount: opts.scrubAmount,
+        revealProgress: reveal < 1 ? revealRamp(0.1, 0.8) : 1,
+        showLabels: opts.barShowLabels ?? false,
+      })
+      ctx.restore()
+    }
   }
 
   // 5. Live dot — position from drawLine's returned pts (same as drawFrame).

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,4 +15,6 @@ export type {
   DegenOptions,
   WindowStyle,
   BadgeVariant,
+  BarPoint,
+  BarMode,
 } from './types'

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -71,6 +71,10 @@ export function resolveTheme(color: string, mode: ThemeMode): LivelinePalette {
     // Background
     bgRgb: isDark ? [10, 10, 10] as [number, number, number] : [255, 255, 255] as [number, number, number],
 
+    // Bars
+    barFill: rgba(r, g, b, isDark ? 0.3 : 0.2),
+    barFillOverlay: rgba(r, g, b, isDark ? 0.08 : 0.06),
+
     // Fonts
     labelFont: '11px "SF Mono", Menlo, Monaco, "Cascadia Code", monospace',
     valueFont: '600 11px "SF Mono", Menlo, monospace',

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,6 +107,13 @@ export interface LivelineProps {
   lineValue?: number              // Current tick value for density transition
   onModeChange?: (mode: 'line' | 'candle') => void  // Built-in toggle callback
 
+  // Bar chart
+  bars?: BarPoint[]             // Bar data (e.g., volume)
+  barMode?: BarMode             // 'default' (bottom strip) or 'overlay' (behind line) — default: 'default'
+  barWidth?: number             // Seconds per bar bucket
+  barColor?: string             // Override accent-derived bar color
+  barLabels?: boolean           // Show value labels on bars (default: false)
+
   className?: string
   style?: CSSProperties
 }
@@ -118,6 +125,13 @@ export interface CandlePoint {
   low: number
   close: number
 }
+
+export interface BarPoint {
+  time: number   // unix seconds — bar period start
+  value: number  // bar height value (e.g., volume)
+}
+
+export type BarMode = 'default' | 'overlay'
 
 export interface LivelinePalette {
   // Line
@@ -164,6 +178,10 @@ export interface LivelinePalette {
 
   // Background (for color fading — labels fade toward bg instead of alpha)
   bgRgb: [number, number, number]
+
+  // Bars
+  barFill: string
+  barFillOverlay: string
 
   // Fonts
   labelFont: string

--- a/src/useLivelineEngine.ts
+++ b/src/useLivelineEngine.ts
@@ -1369,7 +1369,10 @@ export function useLivelineEngine(
             displayBarMaxRef.current = rawBarMax
             barMaxInitedRef.current = true
           } else {
-            displayBarMaxRef.current = lerp(displayBarMaxRef.current, targetBarMaxRef.current, adaptiveSpeed, pausedDt)
+            const gap = Math.abs(displayBarMaxRef.current - targetBarMaxRef.current)
+            const gapRatio = displayBarMaxRef.current > 0 ? Math.min(gap / displayBarMaxRef.current, 1) : 1
+            const barSpeed = RANGE_LERP_SPEED + (1 - gapRatio) * RANGE_ADAPTIVE_BOOST
+            displayBarMaxRef.current = lerp(displayBarMaxRef.current, targetBarMaxRef.current, barSpeed, pausedDt)
             const barStripPx = barMode === 'default' ? barStripH : chartH * BAR_OVERLAY_MAX_RATIO
             const pxThreshold = barStripPx > 0 ? 0.5 * displayBarMaxRef.current / barStripPx : 0.001
             if (Math.abs(displayBarMaxRef.current - targetBarMaxRef.current) < pxThreshold) {

--- a/src/useLivelineEngine.ts
+++ b/src/useLivelineEngine.ts
@@ -81,6 +81,7 @@ const BADGE_Y_LERP_TRANSITIONING = 0.5
 const MOMENTUM_COLOR_LERP = 0.12
 const WINDOW_TRANSITION_MS = 750
 const WINDOW_BUFFER = 0.05
+const WINDOW_BUFFER_NO_BADGE = 0.015
 const VALUE_SNAP_THRESHOLD = 0.001
 const ADAPTIVE_SPEED_BOOST = 0.2
 const MOMENTUM_GREEN: [number, number, number] = [34, 197, 94]
@@ -108,6 +109,7 @@ const LINE_SNAP_THRESHOLD = 0.001
 const RANGE_LERP_SPEED = 0.15
 const RANGE_ADAPTIVE_BOOST = 0.2
 const CANDLE_BUFFER = 0.05
+const CANDLE_BUFFER_NO_BADGE = 0.015
 
 // --- Extracted helper functions (pure computation, called inside draw loop) ---
 
@@ -964,6 +966,10 @@ export function useLivelineEngine(
       // CANDLE MODE PIPELINE
       // ═══════════════════════════════════════════════════════
 
+      // Badge is never visible in pure candle mode (only during line morph),
+      // so always use the smaller buffer to avoid dead space on the right.
+      const candleBuffer = CANDLE_BUFFER_NO_BADGE
+
       // Frozen now — prevent candles from scrolling during reverse morph
       if (hasData) frozenNowRef.current = Date.now() / 1000 - timeDebtRef.current
       const now = (hasData || chartReveal < 0.005)
@@ -1008,7 +1014,7 @@ export function useLivelineEngine(
         cwt.rangeFromMin = displayMinRef.current
         cwt.rangeFromMax = displayMaxRef.current
         const curWindow = displayWindowRef.current
-        const re = now + curWindow * CANDLE_BUFFER
+        const re = now + curWindow * candleBuffer
         const le = re - curWindow
         const targetVis: CandlePoint[] = []
         for (const c of effectiveCandles) {
@@ -1054,14 +1060,14 @@ export function useLivelineEngine(
       const windowResult = updateCandleWindowTransition(
         cfg.windowSecs, transition, displayWindowRef.current,
         displayMinRef.current, displayMaxRef.current,
-        now_ms, now, effectiveCandles, rawLive, candleWidthSecs, CANDLE_BUFFER,
+        now_ms, now, effectiveCandles, rawLive, candleWidthSecs, candleBuffer,
       )
       displayWindowRef.current = windowResult.windowSecs
       const windowSecs = windowResult.windowSecs
       const windowTransProgress = windowResult.windowTransProgress
       const isWindowTransitioning = transition.startMs > 0
 
-      const rightEdge = now + windowSecs * CANDLE_BUFFER
+      const rightEdge = now + windowSecs * candleBuffer
       const leftEdge = rightEdge - windowSecs
 
       // --- Live candle OHLC lerp ---
@@ -1501,13 +1507,14 @@ export function useLivelineEngine(
 
     const chartW = w - pad.left - pad.right
 
-    // Dynamic buffer: when momentum arrows + badge are both on, ensure enough
-    // gap between the live dot and badge for the arrows to fit.
-    // Gap formula: buffer * chartW - 7. Need ~30px for arrows.
-    const needsArrowRoom = cfg.showMomentum
+    // Dynamic buffer: when badge is off, use a smaller buffer so the dot
+    // sits closer to the right edge. When momentum arrows + badge are both
+    // on, ensure enough gap for the arrows to fit.
+    const baseBuffer = cfg.showBadge ? WINDOW_BUFFER : WINDOW_BUFFER_NO_BADGE
+    const needsArrowRoom = cfg.showMomentum && cfg.showBadge
     const buffer = needsArrowRoom
-      ? Math.max(WINDOW_BUFFER, 37 / Math.max(chartW, 1))
-      : WINDOW_BUFFER
+      ? Math.max(baseBuffer, 37 / Math.max(chartW, 1))
+      : baseBuffer
 
     // Window transition
     const transition = windowTransitionRef.current


### PR DESCRIPTION
Bar chart renders time-bucketed data (e.g. volume) alongside the existing line/candlestick chart. Two modes:
- default: bars in a separate strip below the main chart (20% height)
- overlay: semi-transparent bars behind the line

Features:
- Smooth Y-range scaling using the same lerp pattern as the line chart
- Scrub dimming, reveal animations, and choreographed entrance
- Optional value labels (barLabels prop)
- Custom bar color override (barColor prop)
- Works with both line and candlestick chart modes

New props: bars, barMode, barWidth, barColor, barLabels
New types: BarPoint, BarMode

Sample (demo.html):
<img width="1026" height="1280" alt="image" src="https://github.com/user-attachments/assets/6ab2d342-ff25-4d4b-8f01-22b3ea5deac6" />