### PR TITLE
Add timeAxis boolean prop

### DIFF
--- a/src/Liveline.tsx
+++ b/src/Liveline.tsx
@@ -21,6 +21,7 @@ export function Liveline({
   color = '#3b82f6',
   window: windowSecs = 30,
   grid = true,
+  timeAxis = true,
   badge = true,
   momentum = true,
   fill = true,
@@ -111,7 +112,7 @@ export function Liveline({
   const pad = {
     top: paddingOverride?.top ?? 12,
     right: paddingOverride?.right ?? defaultRight,
-    bottom: paddingOverride?.bottom ?? 28,
+    bottom: paddingOverride?.bottom ?? (timeAxis ? 28 : 6),
     left: paddingOverride?.left ?? 12,
   }
 
@@ -188,6 +189,7 @@ export function Liveline({
     windowSecs: effectiveWindowSecs,
     lerpSpeed,
     showGrid: grid,
+    showTimeAxis: timeAxis,
     showBadge: isMultiSeries ? false : badge,
     showMomentum: isMultiSeries ? false : showMomentum,
     momentumOverride,

--- a/src/draw/index.ts
+++ b/src/draw/index.ts
@@ -34,6 +34,7 @@ export interface DrawOptions {
   momentum: Momentum
   arrowState: ArrowState
   showGrid: boolean
+  showTimeAxis: boolean
   showMomentum: boolean
   showPulse: boolean
   showFill: boolean
@@ -130,7 +131,7 @@ export function drawFrame(
   const pts = drawLine(ctx, layout, palette, opts.visible, opts.smoothValue, opts.now, opts.showFill, scrubX, opts.scrubAmount, reveal, opts.now_ms)
 
   // 4. Time axis — same timing as grid
-  {
+  if (opts.showTimeAxis) {
     const timeAlpha = reveal < 1 ? revealRamp(0.15, 0.7) : 1
     if (timeAlpha > 0.01) {
       ctx.save()
@@ -244,6 +245,7 @@ export interface MultiSeriesDrawOptions {
   series: MultiSeriesEntry[]
   now: number
   showGrid: boolean
+  showTimeAxis: boolean
   showPulse: boolean
   referenceLine?: ReferenceLine
   hoverX: number | null
@@ -329,7 +331,7 @@ export function drawMultiFrame(
   }
 
   // 4. Time axis
-  {
+  if (opts.showTimeAxis) {
     const timeAlpha = reveal < 1 ? revealRamp(0.15, 0.7) : 1
     if (timeAlpha > 0.01) {
       ctx.save()
@@ -432,6 +434,7 @@ export interface CandleDrawOptions {
   now: number
   pauseProgress: number
   showGrid: boolean
+  showTimeAxis: boolean
   scrubAmount: number
   hoverX: number | null
   hoverValue: number | null
@@ -615,12 +618,14 @@ export function drawCandleFrame(
   }
 
   // 6. Time axis — fades in (25%–60% of reveal)
-  const timeAlpha = revealRamp(0.25, 0.6)
-  if (timeAlpha > 0.01) {
-    ctx.save()
-    if (timeAlpha < 1) ctx.globalAlpha = timeAlpha
-    drawTimeAxis(ctx, layout, palette, opts.targetWindowSecs, opts.targetWindowSecs, opts.formatTime, opts.timeAxisState, opts.dt)
-    ctx.restore()
+  if (opts.showTimeAxis) {
+    const timeAlpha = revealRamp(0.25, 0.6)
+    if (timeAlpha > 0.01) {
+      ctx.save()
+      if (timeAlpha < 1) ctx.globalAlpha = timeAlpha
+      drawTimeAxis(ctx, layout, palette, opts.targetWindowSecs, opts.targetWindowSecs, opts.formatTime, opts.timeAxisState, opts.dt)
+      ctx.restore()
+    }
   }
 
   // 7. Left edge fade — gradient erase

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,6 +70,7 @@ export interface LivelineProps {
 
   // Feature flags
   grid?: boolean
+  timeAxis?: boolean          // Show X-axis time labels + ticks (default: true)
   badge?: boolean
   momentum?: boolean | Momentum
   fill?: boolean

--- a/src/useLivelineEngine.ts
+++ b/src/useLivelineEngine.ts
@@ -21,6 +21,7 @@ interface EngineConfig {
   windowSecs: number
   lerpSpeed: number
   showGrid: boolean
+  showTimeAxis: boolean
   showBadge: boolean
   showMomentum: boolean
   momentumOverride?: Momentum
@@ -1403,6 +1404,7 @@ export function useLivelineEngine(
         formatTime: cfg.formatTime,
         gridState: gridStateRef.current,
         timeAxisState: timeAxisStateRef.current,
+        showTimeAxis: cfg.showTimeAxis,
         dt: pausedDt,
         targetWindowSecs: cfg.windowSecs,
         tooltipY: cfg.tooltipY,
@@ -1690,6 +1692,7 @@ export function useLivelineEngine(
       formatTime: cfg.formatTime,
       gridState: gridStateRef.current,
       timeAxisState: timeAxisStateRef.current,
+      showTimeAxis: cfg.showTimeAxis,
       dt,
       targetWindowSecs: cfg.windowSecs,
       tooltipY: cfg.tooltipY,
@@ -1849,6 +1852,7 @@ export function useLivelineEngine(
       formatTime: cfg.formatTime,
       gridState: gridStateRef.current,
       timeAxisState: timeAxisStateRef.current,
+      showTimeAxis: cfg.showTimeAxis,
       dt,
       targetWindowSecs: cfg.windowSecs,
       tooltipY: cfg.tooltipY,


### PR DESCRIPTION
## Summary
- Adds `timeAxis?: boolean` prop (default: `true`) to toggle X-axis time labels, ticks, and baseline
- Follows the same pattern as the existing `grid` prop for Y-axis
- Bottom padding auto-adjusts from 28px to 6px when `timeAxis={false}`, unless overridden via `padding.bottom`

## Changes
- `src/types.ts` — Added `timeAxis` to `LivelineProps`
- `src/Liveline.tsx` — Destructure with default, adaptive bottom padding, pass to engine
- `src/useLivelineEngine.ts` — Added to `EngineConfig`, forwarded to all draw option objects
- `src/draw/index.ts` — Conditional guard in `drawFrame`, `drawMultiFrame`, and `drawCandleFrame`

## Usage
```tsx
<Liveline data={data} value={v} timeAxis={false} />
```